### PR TITLE
[libcontacts] Do not postpone fetching indefinitely

### DIFF
--- a/src/seasidecache.cpp
+++ b/src/seasidecache.cpp
@@ -204,6 +204,7 @@ SeasideCache::SeasideCache()
     instancePtr = this;
 
     m_timer.start();
+    m_fetchPostponed.invalidate();
 
 #ifdef HAS_MLITE
     connect(&m_displayLabelOrderConf, SIGNAL(valueChanged()), this, SLOT(displayLabelOrderChanged()));


### PR DESCRIPTION
QElapsedTimer now isValid() on construction, without having started;
it must be explicitly invalidated at startup.
