### PR TITLE
[libcontacts] Filter contacts by address type without QContact data

### DIFF
--- a/rpm/libcontacts-qt5.spec
+++ b/rpm/libcontacts-qt5.spec
@@ -12,7 +12,7 @@ BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires:  pkgconfig(Qt5Contacts)
 BuildRequires:  pkgconfig(Qt5Versit)
 BuildRequires:  pkgconfig(mlite5)
-BuildRequires:  pkgconfig(qtcontacts-sqlite-qt5-extensions)
+BuildRequires:  pkgconfig(qtcontacts-sqlite-qt5-extensions) >= 0.1.1
 
 %description
 %{summary}.

--- a/rpm/libcontacts.spec
+++ b/rpm/libcontacts.spec
@@ -11,7 +11,7 @@ BuildRequires:  pkgconfig(QtCore)
 BuildRequires:  pkgconfig(QtContacts)
 BuildRequires:  pkgconfig(QtVersit)
 BuildRequires:  pkgconfig(mlite)
-BuildRequires:  pkgconfig(qtcontacts-sqlite-extensions)
+BuildRequires:  pkgconfig(qtcontacts-sqlite-extensions) >= 0.1.1
 
 %description
 %{summary}.

--- a/src/seasidecache.cpp
+++ b/src/seasidecache.cpp
@@ -34,6 +34,8 @@
 #include "synchronizelists.h"
 #include "normalization_p.h"
 
+#include "qcontactstatusflags_impl.h"
+
 #include <QCoreApplication>
 #ifdef USING_QTPIM
 #include <QStandardPaths>
@@ -1116,6 +1118,7 @@ void SeasideCache::contactsAvailable()
             } else {
                 item.contact = contact;
             }
+            item.statusFlags = contact.detail<QContactStatusFlags>().flagsValue();
             item.contactState = ContactFetched;
 
              QList<QContactPhoneNumber> phoneNumbers = contact.details<QContactPhoneNumber>();
@@ -1323,6 +1326,7 @@ void SeasideCache::appendContacts(const QList<QContact> &contacts)
                 cacheIds.append(apiId);
                 CacheItem &cacheItem = m_people[iid];
                 cacheItem.contact = contact;
+                cacheItem.statusFlags = contact.detail<QContactStatusFlags>().flagsValue();
                 cacheItem.contactState = ContactFetched;
 
                 if (m_fetchFilter == FilterAll)

--- a/src/seasidecache.h
+++ b/src/seasidecache.h
@@ -35,6 +35,7 @@
 #include "contactcacheexport.h"
 
 #include <qtcontacts-extensions.h>
+#include <QContactStatusFlags>
 
 #include <QContact>
 #include <QContactManager>
@@ -126,7 +127,9 @@ public:
     struct CacheItem
     {
         CacheItem() : itemData(0), modelData(0), iid(0), contactState(ContactAbsent) {}
-        CacheItem(const QContact &contact) : contact(contact), itemData(0), modelData(0), iid(internalId(contact)), contactState(ContactAbsent) {}
+        CacheItem(const QContact &contact)
+            : contact(contact), itemData(0), modelData(0), iid(internalId(contact)),
+              statusFlags(contact.detail<QContactStatusFlags>().flagsValue()), contactState(ContactAbsent) {}
 
         ContactIdType apiId() const { return SeasideCache::apiId(contact); }
 
@@ -134,6 +137,7 @@ public:
         ItemData *itemData;
         ModelData *modelData;
         quint32 iid;
+        quint64 statusFlags;
         ContactState contactState;
     };
 


### PR DESCRIPTION
Allow address type filtering to be performed without retrieving the
full QContact object.
