### PR TITLE
[libcontacts] Use isOnline flag to select FilterOnline contacts

### DIFF
--- a/src/seasidecache.cpp
+++ b/src/seasidecache.cpp
@@ -259,8 +259,7 @@ QContactFilter nonfavoriteFilter()
 
 QContactFilter onlineFilter()
 {
-    // Where presence is available
-    return QContactGlobalPresence::match(QContactPresence::PresenceAvailable);
+    return QContactStatusFlags::matchFlag(QContactStatusFlags::IsOnline);
 }
 
 QContactFilter aggregateFilter()


### PR DESCRIPTION
Note that the presence of this flag in the metadata means we should not
need to query for these contacts explicitly; we should instead extract
the subset of online contacts from the metadata contact set, and
insert those directly into the models.

Depends on: https://github.com/nemomobile/qtcontacts-sqlite/pull/45
