### PR TITLE
[libcontacts] Update name groups correctly

### DIFF
--- a/src/seasidecache.h
+++ b/src/seasidecache.h
@@ -207,6 +207,7 @@ public:
         quint64 statusFlags;
         ContactState contactState;
         ItemListener *listeners;
+        QChar nameGroup;
     };
 
     struct ContactLinkRequest
@@ -231,6 +232,8 @@ public:
         virtual void sourceItemsInserted(int begin, int end) = 0;
 
         virtual void sourceDataChanged(int begin, int end) = 0;
+
+        virtual void sourceItemsChanged() = 0;
 
         virtual void makePopulated() = 0;
         virtual void updateDisplayLabelOrder() = 0;
@@ -300,7 +303,9 @@ public:
 
     static void ensureCompletion(CacheItem *cacheItem);
 
-    static QChar nameGroupForCacheItem(CacheItem *cacheItem);
+    static QChar nameGroup(const CacheItem *cacheItem);
+    static QChar determineNameGroup(const CacheItem *cacheItem);
+
     static QList<QChar> allNameGroups();
     static QHash<QChar, QSet<quint32> > nameGroupMembers();
 
@@ -397,9 +402,9 @@ private:
     void removeContactData(const ContactIdType &contactId, FilterType filter);
     void makePopulated(FilterType filter);
 
-    void addToContactNameGroup(quint32 iid, const QChar &group, QList<QChar> *modifiedGroups = 0);
-    void removeFromContactNameGroup(quint32 iid, const QChar &group, QList<QChar> *modifiedGroups = 0);
-    void notifyNameGroupsChanged(const QList<QChar> &groups);
+    void addToContactNameGroup(quint32 iid, const QChar &group, QSet<QChar> *modifiedGroups = 0);
+    void removeFromContactNameGroup(quint32 iid, const QChar &group, QSet<QChar> *modifiedGroups = 0);
+    void notifyNameGroupsChanged(const QSet<QChar> &groups);
 
     void updateConstituentAggregations(const ContactIdType &contactId);
     void completeContactAggregation(const ContactIdType &contact1Id, const ContactIdType &contact2Id);

--- a/src/src.pro
+++ b/src/src.pro
@@ -10,7 +10,7 @@ target.path = $$PREFIX/lib
 INSTALLS += target
 
 # set version for generated pkgconfig files
-VERSION=0.0.11
+VERSION=0.0.12
 QMAKE_PKGCONFIG_INCDIR = $$PREFIX/include/$${PACKAGENAME}
 QMAKE_PKGCONFIG_LIBDIR = $$PREFIX/lib
 QMAKE_PKGCONFIG_DESTDIR = pkgconfig


### PR DESCRIPTION
Contacts do not change name groups when contact ordering changes, only
if their details change or the dislay label ordering changes.

Also add a function for attached models to handle the completion of
list synchronization.
