### PR TITLE
[libcontacts] Prevent retrieval loop

### DIFF
--- a/src/seasidecache.h
+++ b/src/seasidecache.h
@@ -437,6 +437,7 @@ private:
     QList<ContactIdType> m_changedContacts;
     QList<QContactId> m_contactsToFetchConstituents;
     QList<QContactId> m_contactsToFetchCandidates;
+    QList<QContactId> m_contactsToLinkTo;
     QList<QPair<ContactLinkRequest, ContactLinkRequest> > m_contactPairsToLink;
     QList<QContactRelationship> m_relationshipsToSave;
     QList<QContactRelationship> m_relationshipsToRemove;
@@ -483,8 +484,8 @@ private:
     bool m_updatesPending;
     bool m_refreshRequired;
     bool m_contactsUpdated;
-    QList<ContactIdType> m_constituentIds;
-    QList<ContactIdType> m_candidateIds;
+    QSet<ContactIdType> m_constituentIds;
+    QSet<ContactIdType> m_candidateIds;
 
     struct ResolveData {
         QString first;


### PR DESCRIPTION
Move the contact ID for which we have already retrieved constituents
to a separate list, so that we cannot trigger another fetch for
constituent IDs while waiting for the constituent details to be
retrieved.
