### PR TITLE
[libcontacts] Allow selection of best avatar

### DIFF
--- a/src/seasidecache.h
+++ b/src/seasidecache.h
@@ -339,6 +339,7 @@ public:
 
     static QString generateDisplayLabel(const QContact &contact, DisplayLabelOrder order = FirstNameFirst);
     static QString generateDisplayLabelFromNonNameDetails(const QContact &contact);
+    static QUrl filteredAvatarUrl(const QContact &contact, const QStringList &metadataFragments = QStringList());
 
     static QString normalizePhoneNumber(const QString &input);
 


### PR DESCRIPTION
A contact may have multiple avatars.  This commit adds a function
which allows client to select the best avatar based on the metadata
associated with that avatar.
