### PR TITLE
Revert "Cache the sorted index of contacts"

### DIFF
--- a/src/seasidecache.cpp
+++ b/src/seasidecache.cpp
@@ -877,7 +877,6 @@ void SeasideCache::removeContactData(quint32 iid, FilterType filter)
     for (int i = 0; i < models.count(); ++i)
         models.at(i)->sourceAboutToRemoveItems(row, row);
 
-    m_contactIndices[filter].remove(m_contacts[filter].at(row));
     m_contacts[filter].removeAt(row);
 
     if (filter == FilterAll) {
@@ -1877,7 +1876,6 @@ void SeasideCache::removeRange(FilterType filter, int index, int count)
             m_expiredContacts[apiId(iid)] -= 1;
         }
 
-        m_contactIndices[filter].remove(cacheIds.at(index));
         cacheIds.removeAt(index);
     }
 
@@ -1907,7 +1905,6 @@ int SeasideCache::insertRange(FilterType filter, int index, int count, const QLi
         }
 
         cacheIds.insert(index + i, iid);
-        m_contactIndices[filter].insert(iid, index + i);
     }
 
     for (int i = 0; i < models.count(); ++i)
@@ -1937,7 +1934,6 @@ void SeasideCache::appendContacts(const QList<QContact> &contacts, FilterType fi
                 quint32 iid = internalId(contact);
 
                 cacheIds.append(iid);
-                m_contactIndices[filterType].insert(iid, cacheIds.count() - 1);
 
                 CacheItem &cacheItem = m_people[iid];
 
@@ -2555,27 +2551,8 @@ void SeasideCache::resolveAddress(ResolveListener *listener, const QString &firs
 
 int SeasideCache::contactIndex(quint32 iid, FilterType filterType)
 {
-    QMap<quint32, int> &indices(m_contactIndices[filterType]);
-
-    QMap<quint32, int>::iterator it = indices.find(iid);
-    if (it != indices.end()) {
-        int index = *it;
-
-        const QList<quint32> &cacheIds(m_contacts[filterType]);
-        quint32 contactIid = cacheIds.at(index);
-        if (iid != contactIid) {
-            // This index is no longer correct - we need to update it
-            index = cacheIds.indexOf(iid);
-            if (index == -1) {
-                indices.erase(it);
-            } else {
-                *it = index;
-            }
-        }
-        return index;
-    }
-
-    return -1;
+    const QList<quint32> &cacheIds(m_contacts[filterType]);
+    return cacheIds.indexOf(iid);
 }
 
 QContactRelationship SeasideCache::makeRelationship(const QString &type, const QContact &contact1, const QContact &contact2)

--- a/src/seasidecache.h
+++ b/src/seasidecache.h
@@ -421,7 +421,6 @@ private:
     static QContactRelationship makeRelationship(const QString &type, const QContact &contact1, const QContact &contact2);
 
     QList<quint32> m_contacts[FilterTypesCount];
-    QMap<quint32, int> m_contactIndices[FilterTypesCount];
 
     QBasicTimer m_expiryTimer;
     QBasicTimer m_fetchTimer;


### PR DESCRIPTION
This reverts commit 29356f2857c12eb8c63878d04851c27588393846.
This is causing crashes/regression, so it isn't worth it as a performance
improvement.
