### PR TITLE
[libcontacts] Increase the maximum digits used in minimized phone number...

### DIFF
--- a/rpm/libcontacts-qt5.spec
+++ b/rpm/libcontacts-qt5.spec
@@ -13,7 +13,7 @@ BuildRequires:  pkgconfig(Qt5Contacts)
 BuildRequires:  pkgconfig(Qt5Versit)
 BuildRequires:  pkgconfig(mlite5)
 BuildRequires:  pkgconfig(mlocale5)
-BuildRequires:  pkgconfig(qtcontacts-sqlite-qt5-extensions) >= 0.1.8
+BuildRequires:  pkgconfig(qtcontacts-sqlite-qt5-extensions) >= 0.1.27
 
 %description
 %{summary}.

--- a/rpm/libcontacts.spec
+++ b/rpm/libcontacts.spec
@@ -11,7 +11,7 @@ BuildRequires:  pkgconfig(QtCore)
 BuildRequires:  pkgconfig(QtContacts)
 BuildRequires:  pkgconfig(QtVersit)
 BuildRequires:  pkgconfig(mlite)
-BuildRequires:  pkgconfig(qtcontacts-sqlite-extensions) >= 0.1.8
+BuildRequires:  pkgconfig(qtcontacts-sqlite-extensions) >= 0.1.27
 
 %description
 %{summary}.

--- a/src/seasidecache.cpp
+++ b/src/seasidecache.cpp
@@ -1093,7 +1093,7 @@ QUrl SeasideCache::filteredAvatarUrl(const QContact &contact, const QStringList 
 QString SeasideCache::normalizePhoneNumber(const QString &input)
 {
     // TODO: use a configuration variable to make this configurable
-    static const int maxCharacters = 7;
+    static const int maxCharacters = QtContactsSqliteExtensions::DefaultMaximumPhoneNumberCharacters;
 
     // If the number if not valid, return null
     QString validated(QtContactsSqliteExtensions::normalizePhoneNumber(input, QtContactsSqliteExtensions::ValidatePhoneNumber));


### PR DESCRIPTION
...s

Although 7 digits is typically enough to differentiate phone numbers
in their local forms, an eighth digit is sometimes required to
differentiate between a local number and the voicemail service for
that number.
