### PR TITLE
[libcontacts] Avoid fallback to non-name details when grouping

### DIFF
--- a/src/seasidecache.cpp
+++ b/src/seasidecache.cpp
@@ -718,15 +718,10 @@ QString SeasideCache::determineNameGroup(const CacheItem *cacheItem)
     QString group;
     if (!nameProperty.isEmpty()) {
         group = mLocale.indexBucket(nameProperty);
-    } else  if (!cacheItem->displayLabel.isEmpty()) {
+    } else if (!cacheItem->displayLabel.isEmpty()) {
         group = mLocale.indexBucket(cacheItem->displayLabel);
     }
 
-    if (group.isNull() || !allContactNameGroups.contains(group)) {
-        QString displayLabel = generateDisplayLabelFromNonNameDetails(cacheItem->contact);
-        if (!displayLabel.isEmpty())
-            group = mLocale.indexBucket(displayLabel);
-    }
     if (group.isNull() || !allContactNameGroups.contains(group)) {
         group = QString::fromLatin1("#");   // 'other' group
     }


### PR DESCRIPTION
Including this fallback option leads to the following undesirable scenario:
1. contact details yield a group which is not in the allGroups set
2. the contact is originally grouped in the '#' group
3. when the contact's addresses are later retrieved, the fallback code re-classifies the contact under a group derived from a non-name property of the contact
4. the contact is no longer visible under the original group; the new group has no connection to the contact's displayed name, and cannot be reliably predicted by the user
