### PR TITLE
[libcontacts] Track whether contacts have valid IM accounts

### DIFF
--- a/src/seasidecache.cpp
+++ b/src/seasidecache.cpp
@@ -1854,6 +1854,9 @@ bool SeasideCache::updateContactIndexing(const QContact &oldContact, const QCont
                 oldAddresses.insert(address);
         }
 
+        // Keep track of whether this contact has any valid IM accounts
+        bool hasValid = false;
+
         foreach (const QContactOnlineAccount &account, contact.details<QContactOnlineAccount>()) {
             const StringPair address(addressPair(account));
             if (!validAddressPair(address))
@@ -1865,6 +1868,13 @@ bool SeasideCache::updateContactIndexing(const QContact &oldContact, const QCont
             }
 
             m_onlineAccountIds[address] = iid;
+            hasValid = true;
+        }
+
+        if (hasValid) {
+            item->statusFlags |= HasValidOnlineAccount;
+        } else {
+            item->statusFlags &= ~HasValidOnlineAccount;
         }
 
         if (!oldAddresses.isEmpty()) {

--- a/src/seasidecache.h
+++ b/src/seasidecache.h
@@ -117,6 +117,11 @@ public:
         ContactComplete
     };
 
+    enum {
+        // Must be after the highest bit used in QContactStatusFlags::Flag
+        HasValidOnlineAccount = (QContactStatusFlags::IsOnline << 1)
+    };
+
     struct ItemData
     {
         virtual ~ItemData() {}


### PR DESCRIPTION
Although QContactStatusFlags reports whether an account has any IM
accounts configured, we need to also know whether any of those accounts
are connected to valid telepathy accounts.
