### PR TITLE
[libcontacts] Process fetch-by-ID results synchronously

### DIFF
--- a/src/seasidecache.cpp
+++ b/src/seasidecache.cpp
@@ -2035,7 +2035,7 @@ void SeasideCache::contactsAvailable()
             m_contactsToAppend.insert(type, qMakePair(queryDetailTypes, contacts));
         }
     } else {
-        if (m_activeResolve) {
+        if (m_activeResolve || (request == &m_fetchByIdRequest)) {
             // Process these results immediately
             applyContactUpdates(contacts, partialFetch, queryDetailTypes);
         } else {


### PR DESCRIPTION
When we fetch specific contact IDs as part of the process of linking contacts, we must process the results synchronously so that the fetched contacts will be immediately available from the cache.
