### PR TITLE
[libcontacts] Extend name groups as required for contacts grouping

### DIFF
--- a/src/seasidecache.h
+++ b/src/seasidecache.h
@@ -524,6 +524,7 @@ private:
     QElapsedTimer m_fetchPostponed;
 
     static SeasideCache *instancePtr;
+    static int contactNameGroupCount;
     static QStringList allContactNameGroups;
 };
 


### PR DESCRIPTION
If contacts require previously unused characters under which to be grouped, extend the set of name grouping characters to match.
