### PR TITLE
[libcontacts] Skip validation when normalizing numbers

### DIFF
--- a/src/seasidecache.cpp
+++ b/src/seasidecache.cpp
@@ -1241,22 +1241,23 @@ QUrl SeasideCache::filteredAvatarUrl(const QContact &contact, const QStringList 
     return QUrl();
 }
 
-QString SeasideCache::normalizePhoneNumber(const QString &input)
+QString SeasideCache::normalizePhoneNumber(const QString &input, bool validate)
 {
-    const QtContactsSqliteExtensions::NormalizePhoneNumberFlags normalizeFlags(QtContactsSqliteExtensions::KeepPhoneNumberDialString |
-                                                                               QtContactsSqliteExtensions::ValidatePhoneNumber);
+    QtContactsSqliteExtensions::NormalizePhoneNumberFlags normalizeFlags(QtContactsSqliteExtensions::KeepPhoneNumberDialString);
+    if (validate) {
+        // If the number if not valid, return empty
+        normalizeFlags |= QtContactsSqliteExtensions::ValidatePhoneNumber;
+    }
 
-    // If the number if not valid, return null
     return QtContactsSqliteExtensions::normalizePhoneNumber(input, normalizeFlags);
 }
 
-QString SeasideCache::minimizePhoneNumber(const QString &input)
+QString SeasideCache::minimizePhoneNumber(const QString &input, bool validate)
 {
     // TODO: use a configuration variable to make this configurable
     const int maxCharacters = QtContactsSqliteExtensions::DefaultMaximumPhoneNumberCharacters;
 
-    // If the number if not valid, return null
-    QString validated(normalizePhoneNumber(input));
+    QString validated(normalizePhoneNumber(input, validate));
     if (validated.isNull())
         return validated;
 

--- a/src/seasidecache.h
+++ b/src/seasidecache.h
@@ -326,8 +326,8 @@ public:
     static QString generateDisplayLabelFromNonNameDetails(const QContact &contact);
     static QUrl filteredAvatarUrl(const QContact &contact, const QStringList &metadataFragments = QStringList());
 
-    static QString normalizePhoneNumber(const QString &input);
-    static QString minimizePhoneNumber(const QString &input);
+    static QString normalizePhoneNumber(const QString &input, bool validate = false);
+    static QString minimizePhoneNumber(const QString &input, bool validate = false);
 
     bool event(QEvent *event);
 


### PR DESCRIPTION
In most cases, there is no benefit to validating numbers as they are
normalized, since the data has come from the system. Validation of
data already present in the system is counterproductive since it can
cause us not to process some details.
