### PR TITLE
[libcontacts] Preserve some syncTarget values in backup/restore

### DIFF
--- a/src/seasideexport.cpp
+++ b/src/seasideexport.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2014 Jolla Ltd.
+ * Contact: Matt Vogt <matthew.vogt@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#include "seasideexport.h"
+
+#include "seasidepropertyhandler.h"
+
+#include <QVersitContactExporter>
+
+QList<QVersitDocument> SeasideExport::buildExportContacts(const QList<QContact> &contacts)
+{
+    SeasidePropertyHandler propertyHandler;
+
+    QVersitContactExporter exporter; 
+    exporter.setDetailHandler(&propertyHandler);
+    exporter.exportContacts(contacts); 
+
+    return exporter.documents();
+}
+

--- a/src/seasideexport.h
+++ b/src/seasideexport.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2014 Jolla Ltd.
+ * Contact: Matt Vogt <matthew.vogt@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#ifndef SEASIDEEXPORT_H
+#define SEASIDEEXPORT_H
+
+#include "contactcacheexport.h"
+
+#include <QContact>
+#include <QVersitDocument>
+
+QTCONTACTS_USE_NAMESPACE
+QTVERSIT_USE_NAMESPACE
+
+class CONTACTCACHE_EXPORT SeasideExport
+{
+    SeasideExport();
+    ~SeasideExport();
+
+public:
+    static QList<QVersitDocument> buildExportContacts(const QList<QContact> &contacts);
+};
+
+#endif

--- a/src/seasidepropertyhandler.h
+++ b/src/seasidepropertyhandler.h
@@ -40,7 +40,7 @@
 
 #include <QContact>
 
-#include <QVersitContactImporterPropertyHandler>
+#include <QVersitContactHandler>
 #include <QVersitResourceHandler>
 #include <QVersitDocument>
 #include <QVersitProperty>
@@ -56,10 +56,13 @@ QTVERSIT_USE_NAMESPACE
     a file, and then the path to the file needs to be saved
     to the backend as a contact avatar url detail.
 
+    The X-NEMOMOBILE-SYNCTARGET property is supported for specifying
+    the sync target of a contact.
+
     Also support the X-NEMOMOBILE-ONLINEACCOUNT-DEMO property
     for loading demo online account data.
 */
-class CONTACTCACHE_EXPORT SeasidePropertyHandler : public QVersitContactImporterPropertyHandlerV2
+class CONTACTCACHE_EXPORT SeasidePropertyHandler : public QVersitContactHandler
 {
 public:
     SeasidePropertyHandler();
@@ -69,6 +72,11 @@ public:
     void documentProcessed(const QVersitDocument &, QContact *);
     void propertyProcessed(const QVersitDocument &, const QVersitProperty &property,
                            const QContact &, bool *alreadyProcessed, QList<QContactDetail> * updatedDetails);
+
+    // QVersitContactExporterDetailHandlerV2
+    void contactProcessed(const QContact &, QVersitDocument *);
+    void detailProcessed(const QContact &, const QContactDetail &detail,
+                         const QVersitDocument &, QSet<int> * processedFields, QList<QVersitProperty> * toBeRemoved, QList<QVersitProperty> * toBeAdded);
 };
 
 #endif // PROPERTYHANDLER_H

--- a/src/src.pro
+++ b/src/src.pro
@@ -37,6 +37,7 @@ HEADERS += contactmanagerengine.h
 SOURCES += \
     $$PWD/cacheconfiguration.cpp \
     $$PWD/seasidecache.cpp \
+    $$PWD/seasideexport.cpp \
     $$PWD/seasideimport.cpp \
     $$PWD/seasidepropertyhandler.cpp
 
@@ -44,6 +45,7 @@ HEADERS += \
     $$PWD/cacheconfiguration.h \
     $$PWD/contactcacheexport.h \
     $$PWD/seasidecache.h \
+    $$PWD/seasideexport.h \
     $$PWD/seasideimport.h \
     $$PWD/synchronizelists.h \
     $$PWD/seasidenamegrouper.h \
@@ -53,6 +55,7 @@ headers.files = \
     $$PWD/cacheconfiguration.h \
     $$PWD/contactcacheexport.h \
     $$PWD/seasidecache.h \
+    $$PWD/seasideexport.h \
     $$PWD/seasideimport.h \
     $$PWD/synchronizelists.h \
     $$PWD/seasidenamegrouper.h \


### PR DESCRIPTION
Contacts with 'bluetooth' or 'was_local' sync target values should
preserve these properties during export/import.
