### PR TITLE
[libcontacts] Ensure BT contacts are found for import merge

### DIFF
--- a/src/seasideimport.cpp
+++ b/src/seasideimport.cpp
@@ -94,7 +94,7 @@ QContactFilter localContactFilter()
     filterWasLocal.setValue(QString::fromLatin1("was_local"));
     filterBluetooth.setValue(QString::fromLatin1("bluetooth"));
 
-    return filterLocal | filterWasLocal;
+    return filterLocal | filterWasLocal | filterBluetooth;
 }
 
 bool nameIsEmpty(const QContactName &name)


### PR DESCRIPTION
When merging imported contacts into the existing data set, ensure that
contacts with 'bluetooth' syncTarget values are considered as potential
merge candidates.
