### PR TITLE
[libcontacts] Remove existing IsNot relationship during aggregation

### DIFF
--- a/src/seasidecache.h
+++ b/src/seasidecache.h
@@ -401,6 +401,7 @@ private:
 
     int contactIndex(quint32 iid, FilterType filter);
 
+    static QContactRelationship makeRelationship(const QString &type, const QContactId &id1, const QContactId &id2);
     static QContactRelationship makeRelationship(const QString &type, const QContact &contact1, const QContact &contact2);
 
     QList<quint32> m_contacts[FilterTypesCount];


### PR DESCRIPTION
If a prior IsNot relationship exists, then remove it if aggregation
causes if to become invalid.
