### PR TITLE
[libcontacts] Do not attempt to remove IsNot relationships during merge

### DIFF
--- a/src/seasidecache.cpp
+++ b/src/seasidecache.cpp
@@ -3057,8 +3057,10 @@ void SeasideCache::completeContactAggregation(const QContactId &contact1Id, cons
         m_relationshipsToSave.append(makeRelationship(aggregateRelationshipType, contact1Id, constituentId));
         m_relationshipsToRemove.append(makeRelationship(aggregateRelationshipType, contact2Id, constituentId));
 
-        // If there is an existing IsNot relationship, remove that
-        m_relationshipsToRemove.append(makeRelationship(isNotRelationshipType, contact1Id, constituentId));
+        // If there is an existing IsNot relationship, it would be better to remove it;
+        // unfortunately, we can't be certain that it exists, and if it does not, the
+        // relationship removal will fail - hence, better to ignore the possibility:
+        //m_relationshipsToRemove.append(makeRelationship(isNotRelationshipType, contact1Id, constituentId));
     }
 
     if (!m_relationshipsToSave.isEmpty() || !m_relationshipsToRemove.isEmpty())


### PR DESCRIPTION
We can't be certain that they exist, and if not, they cause the pre-existing aggregation relationships to be preserved.
