### PR TITLE
[performance] get all extra metadata at once if possible

### DIFF
--- a/src/seasidecache.cpp
+++ b/src/seasidecache.cpp
@@ -1718,7 +1718,9 @@ void SeasideCache::startRequest(bool *idleProcessing)
 
                 // Load extra data items that we want to be able to search on, if not already fetched
                 if (unfetchedTypes & SeasideCache::FetchOrganization) {
-                    fetchType = SeasideCache::FetchOrganization;
+                    // since this uses allFilter(), might as well grab
+                    // all the missing detail types
+                    fetchType = unfetchedTypes;
                     m_fetchRequest.setFilter(allFilter());
                 } else if (unfetchedTypes & SeasideCache::FetchPhoneNumber) {
                     fetchType = SeasideCache::FetchPhoneNumber;


### PR DESCRIPTION
Doing multiple queries for this also meant multiple model updates, and multiple contact field parsing on the sqlite side.

This patch halves the time spent at 100% cpu for an app that requests all the search fields.
