### PR TITLE
[libcontacts] Improve vCard contact import API

### DIFF
--- a/src/seasidecontactbuilder.cpp
+++ b/src/seasidecontactbuilder.cpp
@@ -1,0 +1,667 @@
+/*
+ * Copyright (C) 2015 Jolla Mobile
+ * Contact: Chris Adams <chris.adams@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#include "seasidecontactbuilder.h"
+
+#include "seasidecache.h"
+#include "seasidepropertyhandler.h"
+
+#include <QContactDetailFilter>
+#include <QContactFetchHint>
+#include <QContactManager>
+#include <QContactSortOrder>
+#include <QContactSyncTarget>
+
+#include <QContactAddress>
+#include <QContactAnniversary>
+#include <QContactAvatar>
+#include <QContactBirthday>
+#include <QContactEmailAddress>
+#include <QContactFamily>
+#include <QContactGeoLocation>
+#include <QContactGuid>
+#include <QContactHobby>
+#include <QContactName>
+#include <QContactNickname>
+#include <QContactNote>
+#include <QContactOnlineAccount>
+#include <QContactOrganization>
+#include <QContactPhoneNumber>
+#include <QContactRingtone>
+#include <QContactTag>
+#include <QContactUrl>
+
+#include <QContactIdFilter>
+#include <QContactExtendedDetail>
+
+#include <QVersitContactExporter>
+#include <QVersitContactImporter>
+#include <QVersitReader>
+#include <QVersitWriter>
+
+#include <QHash>
+#include <QString>
+#include <QList>
+
+namespace {
+
+QContactFetchHint basicFetchHint()
+{
+    QContactFetchHint fetchHint;
+
+    fetchHint.setOptimizationHints(QContactFetchHint::NoRelationships |
+                                   QContactFetchHint::NoActionPreferences |
+                                   QContactFetchHint::NoBinaryBlobs);
+
+    return fetchHint;
+}
+
+QContactFilter localContactFilter()
+{
+    // Contacts that are local to the device have sync target 'local' or 'was_local' or 'bluetooth'
+    QContactDetailFilter filterLocal, filterWasLocal, filterBluetooth;
+    filterLocal.setDetailType(QContactSyncTarget::Type, QContactSyncTarget::FieldSyncTarget);
+    filterWasLocal.setDetailType(QContactSyncTarget::Type, QContactSyncTarget::FieldSyncTarget);
+    filterBluetooth.setDetailType(QContactSyncTarget::Type, QContactSyncTarget::FieldSyncTarget);
+    filterLocal.setValue(QString::fromLatin1("local"));
+    filterWasLocal.setValue(QString::fromLatin1("was_local"));
+    filterBluetooth.setValue(QString::fromLatin1("bluetooth"));
+
+    return filterLocal | filterWasLocal | filterBluetooth;
+}
+
+bool allCharactersMatchScript(const QString &s, QChar::Script script)
+{
+    for (QString::const_iterator it = s.constBegin(), end = s.constEnd(); it != end; ++it) {
+        if ((*it).script() != script) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool applyNameFixes(QContactName *nameDetail)
+{
+    // Chinese names shouldn't have a middle name, so if it is present in a Han-script-only
+    // name, it is probably wrong and it should be prepended to the first name instead.
+    QString middleName = nameDetail->middleName();
+    if (middleName.isEmpty()) {
+        return false;
+    }
+
+    QString firstName = nameDetail->firstName();
+    QString lastName = nameDetail->lastName();
+    if (!allCharactersMatchScript(middleName, QChar::Script_Han)
+            || (!firstName.isEmpty() && !allCharactersMatchScript(firstName, QChar::Script_Han))
+            || (!lastName.isEmpty() && !allCharactersMatchScript(lastName, QChar::Script_Han))) {
+        return false;
+    }
+
+    nameDetail->setFirstName(middleName + firstName);
+    nameDetail->setMiddleName(QString());
+    return true;
+}
+
+bool nameIsEmpty(const QContactName &name)
+{
+    if (name.isEmpty())
+        return true;
+
+    return (name.prefix().isEmpty() &&
+            name.firstName().isEmpty() &&
+            name.middleName().isEmpty() &&
+            name.lastName().isEmpty() &&
+            name.suffix().isEmpty());
+}
+
+QString contactNameString(const QContact &contact)
+{
+    QStringList details;
+    QContactName name(contact.detail<QContactName>());
+    if (nameIsEmpty(name))
+        return QString();
+
+    details.append(name.prefix());
+    details.append(name.firstName());
+    details.append(name.middleName());
+    details.append(name.lastName());
+    details.append(name.suffix());
+    return details.join(QChar::fromLatin1('|'));
+}
+
+void setNickname(QContact &contact, const QString &text)
+{
+    foreach (const QContactNickname &nick, contact.details<QContactNickname>()) {
+        if (nick.nickname() == text) {
+            return;
+        }
+    }
+
+    QContactNickname nick;
+    nick.setNickname(text);
+    contact.saveDetail(&nick);
+}
+
+
+template<typename T, typename F>
+QVariant detailValue(const T &detail, F field)
+{
+    return detail.value(field);
+}
+
+typedef QMap<int, QVariant> DetailMap;
+
+DetailMap detailValues(const QContactDetail &detail)
+{
+    DetailMap rv(detail.values());
+    return rv;
+}
+
+static bool variantEqual(const QVariant &lhs, const QVariant &rhs)
+{
+    // Work around incorrect result from QVariant::operator== when variants contain QList<int>
+    static const int QListIntType = QMetaType::type("QList<int>");
+
+    const int lhsType = lhs.userType();
+    if (lhsType != rhs.userType()) {
+        return false;
+    }
+
+    if (lhsType == QListIntType) {
+        return (lhs.value<QList<int> >() == rhs.value<QList<int> >());
+    }
+    return (lhs == rhs);
+}
+
+static bool detailValuesSuperset(const QContactDetail &lhs, const QContactDetail &rhs)
+{
+    // True if all values in rhs are present in lhs
+    const DetailMap lhsValues(detailValues(lhs));
+    const DetailMap rhsValues(detailValues(rhs));
+
+    if (lhsValues.count() < rhsValues.count()) {
+        return false;
+    }
+
+    foreach (const DetailMap::key_type &key, rhsValues.keys()) {
+        if (!variantEqual(lhsValues[key], rhsValues[key])) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static void fixupDetail(QContactDetail &)
+{
+}
+
+// Fixup QContactUrl because importer produces incorrectly typed URL field
+static void fixupDetail(QContactUrl &url)
+{
+    QVariant urlField = url.value(QContactUrl::FieldUrl);
+    if (!urlField.isNull()) {
+        QString urlString = urlField.toString();
+        if (!urlString.isEmpty()) {
+            url.setValue(QContactUrl::FieldUrl, QUrl(urlString));
+        } else {
+            url.setValue(QContactUrl::FieldUrl, QVariant());
+        }
+    }
+}
+
+// Fixup QContactOrganization because importer produces invalid department
+static void fixupDetail(QContactOrganization &org)
+{
+    QVariant deptField = org.value(QContactOrganization::FieldDepartment);
+    if (!deptField.isNull()) {
+        QStringList deptList = deptField.toStringList();
+
+        // Remove any empty elements from the list
+        QStringList::iterator it = deptList.begin();
+        while (it != deptList.end()) {
+            if ((*it).isEmpty()) {
+                it = deptList.erase(it);
+            } else {
+                ++it;
+            }
+        }
+
+        if (!deptList.isEmpty()) {
+            org.setValue(QContactOrganization::FieldDepartment, deptList);
+        } else {
+            org.setValue(QContactOrganization::FieldDepartment, QVariant());
+        }
+    }
+}
+
+template<typename T>
+bool mergeContactDetails(QContact *mergeInto, const QContact &mergeFrom, bool singular = false)
+{
+    bool rv = false;
+
+    QList<T> existingDetails(mergeInto->details<T>());
+    if (singular && !existingDetails.isEmpty())
+        return rv;
+
+    foreach (T detail, mergeFrom.details<T>()) {
+        // Make any corrections to the input
+        fixupDetail(detail);
+
+        // See if the contact already has a detail which is a superset of this one
+        bool found = false;
+        foreach (const T &existing, existingDetails) {
+            if (detailValuesSuperset(existing, detail)) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            mergeInto->saveDetail(&detail);
+            rv = true;
+        }
+    }
+
+    return rv;
+}
+
+bool mergeContacts(QContact *mergeInto, const QContact &mergeFrom)
+{
+    bool rv = false;
+
+    // Update the existing contact with any details in the new import
+    rv |= mergeContactDetails<QContactAddress>(mergeInto, mergeFrom);
+    rv |= mergeContactDetails<QContactAnniversary>(mergeInto, mergeFrom);
+    rv |= mergeContactDetails<QContactAvatar>(mergeInto, mergeFrom);
+    rv |= mergeContactDetails<QContactBirthday>(mergeInto, mergeFrom, true);
+    rv |= mergeContactDetails<QContactEmailAddress>(mergeInto, mergeFrom);
+    rv |= mergeContactDetails<QContactFamily>(mergeInto, mergeFrom);
+    rv |= mergeContactDetails<QContactGeoLocation>(mergeInto, mergeFrom);
+    rv |= mergeContactDetails<QContactGuid>(mergeInto, mergeFrom);
+    rv |= mergeContactDetails<QContactHobby>(mergeInto, mergeFrom);
+    rv |= mergeContactDetails<QContactNickname>(mergeInto, mergeFrom);
+    rv |= mergeContactDetails<QContactNote>(mergeInto, mergeFrom);
+    rv |= mergeContactDetails<QContactOnlineAccount>(mergeInto, mergeFrom);
+    rv |= mergeContactDetails<QContactOrganization>(mergeInto, mergeFrom);
+    rv |= mergeContactDetails<QContactPhoneNumber>(mergeInto, mergeFrom);
+    rv |= mergeContactDetails<QContactRingtone>(mergeInto, mergeFrom);
+    rv |= mergeContactDetails<QContactTag>(mergeInto, mergeFrom);
+    rv |= mergeContactDetails<QContactUrl>(mergeInto, mergeFrom);
+    rv |= mergeContactDetails<QContactExtendedDetail>(mergeInto, mergeFrom);
+
+    return rv;
+}
+
+}
+
+SeasideContactBuilder::SeasideContactBuilder()
+    : d(new SeasideContactBuilderPrivate)
+{
+    // defaults.  override in the ctor of your derived type.
+    d->manager = 0;
+    d->propertyHandler = 0;
+    d->unimportableDetailTypes = (QSet<QContactDetail::DetailType>() << QContactDetail::TypeGlobalPresence << QContactDetail::TypeVersion);
+    d->importableSyncTargets = (QStringList() << QLatin1String("was_local") << QLatin1String("bluetooth"));
+}
+
+SeasideContactBuilder::~SeasideContactBuilder()
+{
+    delete d->propertyHandler;
+    delete d;
+}
+
+/*
+ * Returns a pointer to a valid QContactManager.
+ * The default implementation uses the SeasideCache manager.
+ */
+QContactManager *SeasideContactBuilder::manager()
+{
+    if (!d->manager) {
+        d->manager = SeasideCache::manager();
+    }
+
+    return d->manager;
+}
+
+/*
+ * Returns a filter which will return the subset of contacts
+ * in the manager which are potential merge candidates for
+ * the imported contacts (ie, come from the same sync target).
+ *
+ * The default implementation will return a filter which matches
+ * any local / was_local / Bluetooth contact.
+ */
+QContactFilter SeasideContactBuilder::mergeSubsetFilter() const
+{
+    return localContactFilter();
+}
+
+/*
+ * Returns a versit property handler which will be used during
+ * conversion of versit documents into QContact instances.
+ *
+ * The default implementation will return a SeasidePropertyHandler.
+ */
+QVersitContactHandler *SeasideContactBuilder::propertyHandler()
+{
+    if (!d->propertyHandler) {
+        d->propertyHandler = new SeasidePropertyHandler;
+    }
+
+    return d->propertyHandler;
+}
+
+/*
+ * Merge the given (matching) \a local contact into the given
+ * \a import contact, so that the \a import contact could be
+ * later saved in the manager.
+ *
+ * Returns \c true if the \a import contact differed significantly
+ * from the \a local contact (that is, if saving the returned
+ * \a import contact would result in the \a local contact being
+ * updated).
+ *
+ * The \a erase value will be set to true if the given import
+ * contact should be erased from the imported contacts list if
+ * there are no significant differences between it and the local
+ * contact (that is, if the imported contact should be omitted
+ * from later possible store operations, due to the fact that such
+ * a store operation would be a no-op for that contact).
+ *
+ * The default implementation performs a non-destructive merge
+ * and will set \a erase to true, which is the required behaviour
+ * for an "import" style sync.
+ *
+ * Sync implementations which require remote-detail-removal
+ * semantics, for example, should implement this function
+ * differently (eg, prefer-local or prefer-remote), and should
+ * possibly set \a erase to false if they don't wish to prune
+ * the import list prior to save.
+ */
+bool SeasideContactBuilder::mergeLocalIntoImport(QContact &import, const QContact &local, bool *erase)
+{
+    // this implementation does a (mostly) non-destructive detail-addition-merge.
+    // other implementations may choose to prefer-local or prefer-remote.
+    *erase = true;
+    QContact temp(import);
+    import = local;
+    return mergeContacts(&import, temp);
+}
+
+/*
+ * Merge the given (matching) \a otherImport contact into the given
+ * \a import contact.  This function is set \a erase to true if
+ * the \a otherImport contact should be erased from the import list.
+ * The function will return \c true if the \a import contact
+ * is modified as a result of the merge.
+ *
+ * Returns \c true if the \a otherImport contact
+ * should be erased from the import list, otherwise \c false.
+ *
+ * The default implementation performs a non-destructive merge
+ * into the \a import contact, and then sets \a erase to true, which
+ * is the required behaviour for an "import" style sync.
+ *
+ * Sync implementations which require one-to-one mapping between
+ * import contacts and device-stored contacts should set \a erase
+ * to false in this function.
+ */
+bool SeasideContactBuilder::mergeImportIntoImport(QContact &import, QContact &otherImport, bool *erase)
+{
+    *erase = true;
+    return mergeContacts(&import, otherImport);
+}
+
+/*
+ * Import the given Versit \a documents as QContacts and return them.
+ * The default implementation uses a SeasidePropertyHandler during import
+ */
+QList<QContact> SeasideContactBuilder::importContacts(const QList<QVersitDocument> &documents)
+{
+    QVersitContactHandler *handler = propertyHandler();
+    QVersitContactImporter importer;
+    importer.setPropertyHandler(handler);
+    importer.importDocuments(documents);
+    return importer.contacts();
+}
+
+/*
+ * Preprocess the given import contact prior to duplicate detection,
+ * merging, and subsequent storage.
+ *
+ * The default implementation performs some fixes for common issues
+ * encountered in NAME field details, and removes various detail types
+ * which are not supported by the qtcontacts-sqlite manager engine.
+ */
+void SeasideContactBuilder::preprocessContact(QContact &contact)
+{
+    // Fix up name (field ordering) if required
+    QContactName nameDetail = contact.detail<QContactName>();
+    if (applyNameFixes(&nameDetail)) {
+        contact.saveDetail(&nameDetail);
+    }
+
+    // Remove any details that our backend can't store, or which
+    // the client wishes stripped from the imported contacts.
+    foreach (QContactDetail detail, contact.details()) {
+        if (d->unimportableDetailTypes.contains(detail.type())) {
+            qDebug() << "  Removing unimportable detail:" << detail;
+            contact.removeDetail(&detail);
+        } else if (detail.type() == QContactSyncTarget::Type) {
+            // We allow some syncTarget values
+            const QString syncTarget(detail.value<QString>(QContactSyncTarget::FieldSyncTarget));
+            if (!d->importableSyncTargets.contains(syncTarget)) {
+                qDebug() << "  Removing unimportable syncTarget:" << syncTarget;
+                contact.removeDetail(&detail);
+            }
+        }
+    }
+
+    // Set nickname by default if the name is empty
+    if (contactNameString(contact).isEmpty()) {
+        QContactName nameDetail = contact.detail<QContactName>();
+        contact.removeDetail(&nameDetail);
+        if (contact.details<QContactNickname>().isEmpty()) {
+            QString label = contact.detail<QContactDisplayLabel>().label();
+            if (label.isEmpty()) {
+                label = SeasideCache::generateDisplayLabelFromNonNameDetails(contact);
+            }
+            setNickname(contact, label);
+        }
+    }
+}
+
+/*
+ * Returns the index into the \a importedContacts list at which a
+ * duplicate (merge candidate) of the contact at the given
+ * \a contactIndex may be found, or \c -1 if no match is found.
+ *
+ * The default implementation uses a combination of GUID and
+ * name / label matching to determine if a contact is duplicated
+ * within the import list.
+ *
+ * The result will be used to merge any duplicated contacts within
+ * the import list, which is the required behaviour when performing
+ * an "import" style sync.  Any implementation which requires
+ * a one-to-one mapping between import contacts and stored device
+ * contacts should instead return -1 from this function.
+ */
+int SeasideContactBuilder::previousDuplicateIndex(QList<QContact> &importedContacts, int contactIndex)
+{
+    QContact &contact(importedContacts[contactIndex]);
+    const QString guid = contact.detail<QContactGuid>().guid();
+    const QString name = contactNameString(contact);
+    const bool emptyName = name.isEmpty();
+    const QString label = contact.detail<QContactDisplayLabel>().label().isEmpty()
+                        ?SeasideCache::generateDisplayLabelFromNonNameDetails(contact)
+                        : contact.detail<QContactDisplayLabel>().label();
+
+    int previousIndex = -1;
+    QHash<QString, int>::const_iterator git = d->importGuids.find(guid);
+    if (git != d->importGuids.end()) {
+        previousIndex = git.value();
+
+        if (!emptyName) {
+            // If we have a GUID match, but names differ, ignore the match
+            const QContact &previous(importedContacts[previousIndex]);
+            const QString previousName = contactNameString(previous);
+            if (!previousName.isEmpty() && (previousName != name)) {
+                previousIndex = -1;
+
+                // Remove the conflicting GUID from this contact
+                QContactGuid guidDetail = contact.detail<QContactGuid>();
+                contact.removeDetail(&guidDetail);
+            }
+        }
+    }
+    if (previousIndex == -1) {
+        if (!emptyName) {
+            QHash<QString, int>::const_iterator nit = d->importNames.find(name);
+            if (nit != d->importNames.end()) {
+                previousIndex = nit.value();
+            }
+        } else if (!label.isEmpty()) {
+            // Only if name is empty, use displayLabel - probably SIM import
+            QHash<QString, int>::const_iterator lit = d->importLabels.find(label);
+            if (lit != d->importLabels.end()) {
+                previousIndex = lit.value();
+            }
+        }
+    }
+
+    if (previousIndex == -1) {
+        // No previous duplicate detected.  This is a new contact.
+        // Update our identification hashes with this contact's info.
+        if (!guid.isEmpty()) {
+            d->importGuids.insert(guid, contactIndex);
+        }
+        if (!emptyName) {
+            d->importNames.insert(name, contactIndex);
+        } else if (!label.isEmpty()) {
+            d->importLabels.insert(label, contactIndex);
+        }
+    }
+
+    return previousIndex;
+}
+
+/*
+ * Build up any indexes of information required to later determine
+ * whether a given import contact is already represented on the
+ * device (ie, if the "new" contact is actually a new contact,
+ * or if it constitutes an update to a previously imported contact).
+ *
+ * The default implementation builds up hashes of GUID, name and
+ * label information to use later during match detection.
+ */
+void SeasideContactBuilder::buildLocalDeviceContactIndexes()
+{
+    // Find all names and GUIDs for local contacts that might match these contacts
+    QContactFetchHint fetchHint(basicFetchHint());
+    fetchHint.setDetailTypesHint(QList<QContactDetail::DetailType>() << QContactName::Type << QContactNickname::Type << QContactGuid::Type);
+
+    QContactManager *mgr(manager());
+
+    foreach (const QContact &contact, mgr->contacts(mergeSubsetFilter(), QList<QContactSortOrder>(), fetchHint)) {
+        const QString guid = contact.detail<QContactGuid>().guid();
+        const QString name = contactNameString(contact);
+
+        if (!guid.isEmpty()) {
+            d->existingGuids.insert(guid, contact.id());
+        }
+        if (!name.isEmpty()) {
+            d->existingNames.insert(name, contact.id());
+            d->existingContactNames.insert(contact.id(), name);
+        }
+        foreach (const QContactNickname &nick, contact.details<QContactNickname>()) {
+            d->existingNicknames.insert(nick.nickname(), contact.id());
+        }
+    }
+}
+
+/*
+ * Returns the id of an existing local device contact which matches
+ * the given import \a contact.  This local device contact is a
+ * previously-imported version of the "new" import \a contact.
+ *
+ * The default implementation uses the previously cached GUID,
+ * name and label information to perform the match detection.
+ */
+QContactId SeasideContactBuilder::matchingLocalContactId(QContact &contact)
+{
+    const QString guid = contact.detail<QContactGuid>().guid();
+    const QString name = contactNameString(contact);
+    const bool emptyName = name.isEmpty();
+    QContactId existingId;
+
+    QHash<QString, QContactId>::const_iterator git = d->existingGuids.find(guid);
+    if (git != d->existingGuids.end()) {
+        existingId = *git;
+
+        if (!emptyName) {
+            // If we have a GUID match, but names differ, ignore the match
+            QMap<QContactId, QString>::iterator nit = d->existingContactNames.find(existingId);
+            if (nit != d->existingContactNames.end()) {
+                const QString &existingName(*nit);
+                if (!existingName.isEmpty() && (existingName != name)) {
+                    existingId = QContactId();
+
+                    // Remove the conflicting GUID from this contact
+                    QContactGuid guidDetail = contact.detail<QContactGuid>();
+                    contact.removeDetail(&guidDetail);
+                }
+            }
+        }
+    }
+    if (existingId.isNull()) {
+        if (!emptyName) {
+            QHash<QString, QContactId>::const_iterator nit = d->existingNames.find(name);
+            if (nit != d->existingNames.end()) {
+                existingId = *nit;
+            }
+        } else {
+            foreach (const QContactNickname nick, contact.details<QContactNickname>()) {
+                const QString nickname(nick.nickname());
+                if (!nickname.isEmpty()) {
+                    QHash<QString, QContactId>::const_iterator nit = d->existingNicknames.find(nickname);
+                    if (nit != d->existingNicknames.end()) {
+                        existingId = *nit;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    return existingId;
+}

--- a/src/seasideimport.cpp
+++ b/src/seasideimport.cpp
@@ -31,482 +31,79 @@
 
 #include "seasideimport.h"
 
-#include "seasidecache.h"
-#include "seasidepropertyhandler.h"
-
-#include <QContactDetailFilter>
-#include <QContactFetchHint>
-#include <QContactManager>
-#include <QContactSortOrder>
-#include <QContactSyncTarget>
-
-#include <QContactAddress>
-#include <QContactAnniversary>
-#include <QContactAvatar>
-#include <QContactBirthday>
-#include <QContactEmailAddress>
-#include <QContactFamily>
-#include <QContactGeoLocation>
-#include <QContactGuid>
-#include <QContactHobby>
-#include <QContactName>
-#include <QContactNickname>
-#include <QContactNote>
-#include <QContactOnlineAccount>
-#include <QContactOrganization>
-#include <QContactPhoneNumber>
-#include <QContactRingtone>
-#include <QContactTag>
-#include <QContactUrl>
-
 #include <QContactIdFilter>
-#include <QContactExtendedDetail>
-
-#include <QVersitContactExporter>
-#include <QVersitContactImporter>
-#include <QVersitReader>
-#include <QVersitWriter>
-
-#include <QHash>
-#include <QString>
+#include <QContact>
+#include <QContactManager>
 
 namespace {
-
-QContactFetchHint basicFetchHint()
-{
-    QContactFetchHint fetchHint;
-
-    fetchHint.setOptimizationHints(QContactFetchHint::NoRelationships |
-                                   QContactFetchHint::NoActionPreferences |
-                                   QContactFetchHint::NoBinaryBlobs);
-
-    return fetchHint;
-}
-
-QContactFilter localContactFilter()
-{
-    // Contacts that are local to the device have sync target 'local' or 'was_local' or 'bluetooth'
-    QContactDetailFilter filterLocal, filterWasLocal, filterBluetooth;
-    filterLocal.setDetailType(QContactSyncTarget::Type, QContactSyncTarget::FieldSyncTarget);
-    filterWasLocal.setDetailType(QContactSyncTarget::Type, QContactSyncTarget::FieldSyncTarget);
-    filterBluetooth.setDetailType(QContactSyncTarget::Type, QContactSyncTarget::FieldSyncTarget);
-    filterLocal.setValue(QString::fromLatin1("local"));
-    filterWasLocal.setValue(QString::fromLatin1("was_local"));
-    filterBluetooth.setValue(QString::fromLatin1("bluetooth"));
-
-    return filterLocal | filterWasLocal | filterBluetooth;
-}
-
-bool nameIsEmpty(const QContactName &name)
-{
-    if (name.isEmpty())
-        return true;
-
-    return (name.prefix().isEmpty() &&
-            name.firstName().isEmpty() &&
-            name.middleName().isEmpty() &&
-            name.lastName().isEmpty() &&
-            name.suffix().isEmpty());
-}
-
-QString contactNameString(const QContact &contact)
-{
-    QStringList details;
-    QContactName name(contact.detail<QContactName>());
-    if (nameIsEmpty(name))
-        return QString();
-
-    details.append(name.prefix());
-    details.append(name.firstName());
-    details.append(name.middleName());
-    details.append(name.lastName());
-    details.append(name.suffix());
-    return details.join(QChar::fromLatin1('|'));
-}
-
-
-template<typename T, typename F>
-QVariant detailValue(const T &detail, F field)
-{
-    return detail.value(field);
-}
-
-typedef QMap<int, QVariant> DetailMap;
-
-DetailMap detailValues(const QContactDetail &detail)
-{
-    DetailMap rv(detail.values());
-    return rv;
-}
-
-static bool variantEqual(const QVariant &lhs, const QVariant &rhs)
-{
-    // Work around incorrect result from QVariant::operator== when variants contain QList<int>
-    static const int QListIntType = QMetaType::type("QList<int>");
-
-    const int lhsType = lhs.userType();
-    if (lhsType != rhs.userType()) {
-        return false;
-    }
-
-    if (lhsType == QListIntType) {
-        return (lhs.value<QList<int> >() == rhs.value<QList<int> >());
-    }
-    return (lhs == rhs);
-}
-
-static bool detailValuesSuperset(const QContactDetail &lhs, const QContactDetail &rhs)
-{
-    // True if all values in rhs are present in lhs
-    const DetailMap lhsValues(detailValues(lhs));
-    const DetailMap rhsValues(detailValues(rhs));
-
-    if (lhsValues.count() < rhsValues.count()) {
-        return false;
-    }
-
-    foreach (const DetailMap::key_type &key, rhsValues.keys()) {
-        if (!variantEqual(lhsValues[key], rhsValues[key])) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-static void fixupDetail(QContactDetail &)
-{
-}
-
-// Fixup QContactUrl because importer produces incorrectly typed URL field
-static void fixupDetail(QContactUrl &url)
-{
-    QVariant urlField = url.value(QContactUrl::FieldUrl);
-    if (!urlField.isNull()) {
-        QString urlString = urlField.toString();
-        if (!urlString.isEmpty()) {
-            url.setValue(QContactUrl::FieldUrl, QUrl(urlString));
-        } else {
-            url.setValue(QContactUrl::FieldUrl, QVariant());
-        }
+    QContactFetchHint basicFetchHint()
+    {
+        QContactFetchHint fetchHint;
+        fetchHint.setOptimizationHints(QContactFetchHint::NoRelationships |
+                                       QContactFetchHint::NoActionPreferences |
+                                       QContactFetchHint::NoBinaryBlobs);
+        return fetchHint;
     }
 }
 
-// Fixup QContactOrganization because importer produces invalid department
-static void fixupDetail(QContactOrganization &org)
-{
-    QVariant deptField = org.value(QContactOrganization::FieldDepartment);
-    if (!deptField.isNull()) {
-        QStringList deptList = deptField.toStringList();
-
-        // Remove any empty elements from the list
-        QStringList::iterator it = deptList.begin();
-        while (it != deptList.end()) {
-            if ((*it).isEmpty()) {
-                it = deptList.erase(it);
-            } else {
-                ++it;
-            }
-        }
-
-        if (!deptList.isEmpty()) {
-            org.setValue(QContactOrganization::FieldDepartment, deptList);
-        } else {
-            org.setValue(QContactOrganization::FieldDepartment, QVariant());
-        }
-    }
-}
-
-template<typename T>
-bool updateExistingDetails(QContact *updateContact, const QContact &importedContact, bool singular = false)
-{
-    bool rv = false;
-
-    QList<T> existingDetails(updateContact->details<T>());
-    if (singular && !existingDetails.isEmpty())
-        return rv;
-
-    foreach (T detail, importedContact.details<T>()) {
-        // Make any corrections to the input
-        fixupDetail(detail);
-
-        // See if the contact already has a detail which is a superset of this one
-        bool found = false;
-        foreach (const T &existing, existingDetails) {
-            if (detailValuesSuperset(existing, detail)) {
-                found = true;
-                break;
-            }
-        }
-        if (!found) {
-            updateContact->saveDetail(&detail);
-            rv = true;
-        }
-    }
-
-    return rv;
-}
-
-bool mergeIntoExistingContact(QContact *updateContact, const QContact &importedContact)
-{
-    bool rv = false;
-
-    // Update the existing contact with any details in the new import
-    rv |= updateExistingDetails<QContactAddress>(updateContact, importedContact);
-    rv |= updateExistingDetails<QContactAnniversary>(updateContact, importedContact);
-    rv |= updateExistingDetails<QContactAvatar>(updateContact, importedContact);
-    rv |= updateExistingDetails<QContactBirthday>(updateContact, importedContact, true);
-    rv |= updateExistingDetails<QContactEmailAddress>(updateContact, importedContact);
-    rv |= updateExistingDetails<QContactFamily>(updateContact, importedContact);
-    rv |= updateExistingDetails<QContactGeoLocation>(updateContact, importedContact);
-    rv |= updateExistingDetails<QContactGuid>(updateContact, importedContact);
-    rv |= updateExistingDetails<QContactHobby>(updateContact, importedContact);
-    rv |= updateExistingDetails<QContactNickname>(updateContact, importedContact);
-    rv |= updateExistingDetails<QContactNote>(updateContact, importedContact);
-    rv |= updateExistingDetails<QContactOnlineAccount>(updateContact, importedContact);
-    rv |= updateExistingDetails<QContactOrganization>(updateContact, importedContact);
-    rv |= updateExistingDetails<QContactPhoneNumber>(updateContact, importedContact);
-    rv |= updateExistingDetails<QContactRingtone>(updateContact, importedContact);
-    rv |= updateExistingDetails<QContactTag>(updateContact, importedContact);
-    rv |= updateExistingDetails<QContactUrl>(updateContact, importedContact);
-    rv |= updateExistingDetails<QContactExtendedDetail>(updateContact, importedContact);
-
-    return rv;
-}
-
-bool updateExistingContact(QContact *updateContact, const QContact &contact)
-{
-    // Replace the imported contact with the existing version
-    QContact importedContact(*updateContact);
-    *updateContact = contact;
-
-    return mergeIntoExistingContact(updateContact, importedContact);
-}
-
-void setNickname(QContact &contact, const QString &text)
-{
-    foreach (const QContactNickname &nick, contact.details<QContactNickname>()) {
-        if (nick.nickname() == text) {
-            return;
-        }
-    }
-
-    QContactNickname nick;
-    nick.setNickname(text);
-    contact.saveDetail(&nick);
-}
-
-}
-
-QList<QContact> SeasideImport::buildImportContacts(const QList<QVersitDocument> &details, int *newCount, int *updatedCount)
+QList<QContact> SeasideImport::buildImportContacts(const QList<QVersitDocument> &details, int *newCount, int *updatedCount, int *ignoredCount, SeasideContactBuilder *contactBuilder)
 {
     if (newCount)
         *newCount = 0;
     if (updatedCount)
         *updatedCount = 0;
+    bool eraseMatch = false;
 
-    // Read the contacts from the import details
-    SeasidePropertyHandler propertyHandler;
-    QVersitContactImporter importer;
-    importer.setPropertyHandler(&propertyHandler);
-    importer.importDocuments(details);
+    SeasideContactBuilder *builder = contactBuilder
+                                   ? contactBuilder
+                                   : new SeasideContactBuilder;
+    QList<QContact> importedContacts = builder->importContacts(details);
 
-    QList<QContact> importedContacts(importer.contacts());
-
-    QHash<QString, int> importGuids;
-    QHash<QString, int> importNames;
-    QHash<QString, int> importLabels;
-
-    QSet<QContactDetail::DetailType> unimportableDetailTypes;
-    unimportableDetailTypes.insert(QContactDetail::TypeGlobalPresence);
-    unimportableDetailTypes.insert(QContactDetail::TypeVersion);
-
-    // Merge any duplicates in the import list
+    // Preprocess the imported contacts and merge any duplicates in the import list
     QList<QContact>::iterator it = importedContacts.begin();
     while (it != importedContacts.end()) {
-        QContact &contact(*it);
-
-        // Remove any details that our backend can't store
-        foreach (QContactDetail detail, contact.details()) {
-            if (detail.type() == QContactSyncTarget::Type) {
-                // We allow some syncTarget values
-                const QString syncTarget(detail.value<QString>(QContactSyncTarget::FieldSyncTarget));
-                if (syncTarget == QStringLiteral("was_local") ||
-                    syncTarget == QStringLiteral("bluetooth")) {
-                    // These values are permissible
-                } else {
-                    qDebug() << "  Removing unimportable syncTarget:" << syncTarget;
-                    contact.removeDetail(&detail);
-                }
-            } else if (unimportableDetailTypes.contains(detail.type())) {
-                qDebug() << "  Removing unimportable detail:" << detail;
-                contact.removeDetail(&detail);
-            }
-        }
-
-        const QString guid = contact.detail<QContactGuid>().guid();
-        const QString name = contactNameString(contact);
-        const bool emptyName = name.isEmpty();
-
-        QString label;
-        if (emptyName) {
-            QContactName nameDetail = contact.detail<QContactName>();
-            contact.removeDetail(&nameDetail);
-
-            label = contact.detail<QContactDisplayLabel>().label();
-            if (label.isEmpty()) {
-                label = SeasideCache::generateDisplayLabelFromNonNameDetails(contact);
-            }
-        }
-
-        int previousIndex = -1;
-        QHash<QString, int>::const_iterator git = importGuids.find(guid);
-        if (git != importGuids.end()) {
-            previousIndex = git.value();
-
-            if (!emptyName) {
-                // If we have a GUID match, but names differ, ignore the match
-                const QContact &previous(importedContacts[previousIndex]);
-                const QString previousName = contactNameString(previous);
-                if (!previousName.isEmpty() && (previousName != name)) {
-                    previousIndex = -1;
-
-                    // Remove the conflicting GUID from this contact
-                    QContactGuid guidDetail = contact.detail<QContactGuid>();
-                    contact.removeDetail(&guidDetail);
-                }
-            }
-        }
-        if (previousIndex == -1) {
-            if (!emptyName) {
-                QHash<QString, int>::const_iterator nit = importNames.find(name);
-                if (nit != importNames.end()) {
-                    previousIndex = nit.value();
-                }
-            } else if (!label.isEmpty()) {
-                // Only if name is empty, use displayLabel - probably SIM import
-                QHash<QString, int>::const_iterator lit = importLabels.find(label);
-                if (lit != importLabels.end()) {
-                    previousIndex = lit.value();
-                }
-            }
-        }
-
+        builder->preprocessContact(*it);
+        int previousIndex = builder->previousDuplicateIndex(importedContacts, it - importedContacts.begin());
         if (previousIndex != -1) {
             // Combine these duplicate contacts
             QContact &previous(importedContacts[previousIndex]);
-            mergeIntoExistingContact(&previous, contact);
-
-            it = importedContacts.erase(it);
+            builder->mergeImportIntoImport(previous, *it, &eraseMatch);
+            if (eraseMatch) {
+                it = importedContacts.erase(it);
+            } else {
+                ++it;
+            }
         } else {
-            const int index = it - importedContacts.begin();
-            if (!guid.isEmpty()) {
-                importGuids.insert(guid, index);
-            }
-            if (!emptyName) {
-                importNames.insert(name, index);
-            } else if (!label.isEmpty()) {
-                importLabels.insert(label, index);
-
-                if (contact.details<QContactNickname>().isEmpty()) {
-                    // Modify this contact to have the label as a nickname
-                    setNickname(contact, label);
-                }
-            }
-
             ++it;
         }
     }
 
-    // Find all names and GUIDs for local contacts that might match these contacts
-    QContactFetchHint fetchHint(basicFetchHint());
-    fetchHint.setDetailTypesHint(QList<QContactDetail::DetailType>() << QContactName::Type << QContactNickname::Type << QContactGuid::Type);
-
-    QHash<QString, QContactId> existingGuids;
-    QHash<QString, QContactId> existingNames;
-    QMap<QContactId, QString> existingContactNames;
-    QHash<QString, QContactId> existingNicknames;
-
-    QContactManager *mgr(SeasideCache::manager());
-
-    foreach (const QContact &contact, mgr->contacts(localContactFilter(), QList<QContactSortOrder>(), fetchHint)) {
-        const QString guid = contact.detail<QContactGuid>().guid();
-        const QString name = contactNameString(contact);
-
-        if (!guid.isEmpty()) {
-            existingGuids.insert(guid, contact.id());
-        }
-        if (!name.isEmpty()) {
-            existingNames.insert(name, contact.id());
-            existingContactNames.insert(contact.id(), name);
-        }
-        foreach (const QContactNickname &nick, contact.details<QContactNickname>()) {
-            existingNicknames.insert(nick.nickname(), contact.id());
-        }
-    }
+    // Build up information about local device contacts, so we can detect matches
+    // in order to correctly set the appropriate ContactId in the imported contacts
+    // prior to save (thereby ensuring correct add vs update save semantics).
+    builder->buildLocalDeviceContactIndexes();
 
     // Find any imported contacts that match contacts we already have
     QMap<QContactId, int> existingIds;
-
     it = importedContacts.begin();
     while (it != importedContacts.end()) {
-        const QString guid = (*it).detail<QContactGuid>().guid();
-        const QString name = contactNameString(*it);
-        const bool emptyName = name.isEmpty();
-
-        QContactId existingId;
-
-        QHash<QString, QContactId>::const_iterator git = existingGuids.find(guid);
-        if (git != existingGuids.end()) {
-            existingId = *git;
-
-            if (!emptyName) {
-                // If we have a GUID match, but names differ, ignore the match
-                QMap<QContactId, QString>::iterator nit = existingContactNames.find(existingId);
-                if (nit != existingContactNames.end()) {
-                    const QString &existingName(*nit);
-                    if (!existingName.isEmpty() && (existingName != name)) {
-                        existingId = QContactId();
-
-                        // Remove the conflicting GUID from this contact
-                        QContactGuid guidDetail = (*it).detail<QContactGuid>();
-                        (*it).removeDetail(&guidDetail);
-                    }
-                }
-            }
-        }
-        if (existingId.isNull()) {
-            if (!emptyName) {
-                QHash<QString, QContactId>::const_iterator nit = existingNames.find(name);
-                if (nit != existingNames.end()) {
-                    existingId = *nit;
-                }
-            } else {
-                foreach (const QContactNickname nick, (*it).details<QContactNickname>()) {
-                    const QString nickname(nick.nickname());
-                    if (!nickname.isEmpty()) {
-                        QHash<QString, QContactId>::const_iterator nit = existingNicknames.find(nickname);
-                        if (nit != existingNicknames.end()) {
-                            existingId = *nit;
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-
+        QContactId existingId = builder->matchingLocalContactId(*it);
         if (!existingId.isNull()) {
             QMap<QContactId, int>::iterator eit = existingIds.find(existingId);
             if (eit == existingIds.end()) {
+                // this match hasn't been seen before.
                 existingIds.insert(existingId, (it - importedContacts.begin()));
-
                 ++it;
             } else {
-                // Combine these contacts with matching names
+                // another import contact which matches that local contact has
+                // been seen already. Merge these both-matching import contacts.
                 QContact &previous(importedContacts[*eit]);
-                mergeIntoExistingContact(&previous, *it);
-
-                it = importedContacts.erase(it);
+                builder->mergeImportIntoImport(previous, *it, &eraseMatch);
+                if (eraseMatch) {
+                    it = importedContacts.erase(it);
+                } else {
+                    ++it;
+                }
             }
         } else {
             ++it;
@@ -521,17 +118,19 @@ QList<QContact> SeasideImport::buildImportContacts(const QList<QVersitDocument> 
 
         QSet<QContactId> modifiedContacts;
         QSet<QContactId> unmodifiedContacts;
+        QHash<QContactId, bool> unmodifiedErase;
 
-        foreach (const QContact &contact, mgr->contacts(idFilter & localContactFilter(), QList<QContactSortOrder>(), basicFetchHint())) {
+        foreach (const QContact &contact, builder->manager()->contacts(idFilter & builder->mergeSubsetFilter(), QList<QContactSortOrder>(), basicFetchHint())) {
             QMap<QContactId, int>::const_iterator it = existingIds.find(contact.id());
             if (it != existingIds.end()) {
                 // Update the existing version of the contact with any new details
                 QContact &importContact(importedContacts[*it]);
-                bool modified = updateExistingContact(&importContact, contact);
+                bool modified = builder->mergeLocalIntoImport(importContact, contact, &eraseMatch);
                 if (modified) {
                     modifiedContacts.insert(importContact.id());
                 } else {
                     unmodifiedContacts.insert(importContact.id());
+                    unmodifiedErase.insert(importContact.id(), eraseMatch);
                 }
             } else {
                 qWarning() << "unable to update existing contact:" << contact.id();
@@ -544,8 +143,8 @@ QList<QContact> SeasideImport::buildImportContacts(const QList<QVersitDocument> 
                 const QContact &importContact(*it);
                 const QContactId contactId(importContact.id());
 
-                if (unmodifiedContacts.contains(contactId) && !modifiedContacts.contains(contactId)) {
-                    // This contact was not modified by import - don't update it
+                if (!modifiedContacts.contains(contactId) && unmodifiedContacts.contains(contactId) && unmodifiedErase.value(contactId, false) == true) {
+                    // This contact was not modified by import and should be erased from the import list - don't update it
                     it = importedContacts.erase(it);
                     --existingCount;
                 } else {
@@ -559,6 +158,8 @@ QList<QContact> SeasideImport::buildImportContacts(const QList<QVersitDocument> 
         *updatedCount = existingCount;
     if (newCount)
         *newCount = importedContacts.count() - existingCount;
+    if (ignoredCount) // duplicates or insignificant updates
+        *ignoredCount = details.count() - importedContacts.count();
 
     return importedContacts;
 }

--- a/src/seasidepropertyhandler.h
+++ b/src/seasidepropertyhandler.h
@@ -37,6 +37,7 @@
 
 #include <QString>
 #include <QByteArray>
+#include <QVariantMap>
 
 #include <QContact>
 
@@ -62,10 +63,11 @@ QTVERSIT_USE_NAMESPACE
     Also support the X-NEMOMOBILE-ONLINEACCOUNT-DEMO property
     for loading demo online account data.
 */
+class SeasidePropertyHandlerPrivate;
 class CONTACTCACHE_EXPORT SeasidePropertyHandler : public QVersitContactHandler
 {
 public:
-    SeasidePropertyHandler();
+    SeasidePropertyHandler(const QSet<QContactDetail::DetailType> &nonexportableDetails = QSet<QContactDetail::DetailType>());
     ~SeasidePropertyHandler();
 
     // QVersitContactImporterPropertyHandlerV2
@@ -77,6 +79,9 @@ public:
     void contactProcessed(const QContact &, QVersitDocument *);
     void detailProcessed(const QContact &, const QContactDetail &detail,
                          const QVersitDocument &, QSet<int> * processedFields, QList<QVersitProperty> * toBeRemoved, QList<QVersitProperty> * toBeAdded);
+
+private:
+    SeasidePropertyHandlerPrivate *priv;
 };
 
 #endif // PROPERTYHANDLER_H

--- a/src/src.pro
+++ b/src/src.pro
@@ -38,6 +38,7 @@ SOURCES += \
     $$PWD/seasidecache.cpp \
     $$PWD/seasideexport.cpp \
     $$PWD/seasideimport.cpp \
+    $$PWD/seasidecontactbuilder.cpp \
     $$PWD/seasidepropertyhandler.cpp
 
 HEADERS += \
@@ -46,6 +47,7 @@ HEADERS += \
     $$PWD/seasidecache.h \
     $$PWD/seasideexport.h \
     $$PWD/seasideimport.h \
+    $$PWD/seasidecontactbuilder.h \
     $$PWD/synchronizelists.h \
     $$PWD/seasidenamegrouper.h \
     $$PWD/seasidepropertyhandler.h
@@ -56,6 +58,7 @@ headers.files = \
     $$PWD/seasidecache.h \
     $$PWD/seasideexport.h \
     $$PWD/seasideimport.h \
+    $$PWD/seasidecontactbuilder.h \
     $$PWD/synchronizelists.h \
     $$PWD/seasidenamegrouper.h \
     $$PWD/seasidepropertyhandler.h


### PR DESCRIPTION
This commit improves the SeasideImport API by allowing clients to
specify their own SeasideContactBuilder implementation when
converting the list of Versit documents into storage QContacts.

The SeasideContactBuilder allows the client to parametrise things
like the contact filter used to determine the subset of mergable
contacts, the merge strategy to use, and so on.