### PR TITLE
[libcontacts] Some scripts imply name token ordering

### DIFF
--- a/src/seasidecache.h
+++ b/src/seasidecache.h
@@ -320,6 +320,9 @@ public:
     static const QList<quint32> *contacts(FilterType filterType);
     static bool isPopulated(FilterType filterType);
 
+    static QString primaryName(const QString &firstName, const QString &lastName);
+    static QString secondaryName(const QString &firstName, const QString &lastName);
+
     static QString generateDisplayLabel(const QContact &contact, DisplayLabelOrder order = FirstNameFirst);
     static QString generateDisplayLabelFromNonNameDetails(const QContact &contact);
     static QUrl filteredAvatarUrl(const QContact &contact, const QStringList &metadataFragments = QStringList());


### PR DESCRIPTION
For a specific set of character scripts, if a contact's first and last
names are entirely composed of that script, then that (most likely)
implies a cultural ordering for given/family name tokens that should
override the device setting.