### PR TITLE
[libcontacts] Fix unit tests

### DIFF
--- a/libcontacts.pro
+++ b/libcontacts.pro
@@ -1,4 +1,5 @@
 TEMPLATE = subdirs
 SUBDIRS = src tests
+OTHER_FILES += rpm/libcontacts-qt5.spec
 
 tests.depends = src

--- a/rpm/libcontacts-qt5.spec
+++ b/rpm/libcontacts-qt5.spec
@@ -22,6 +22,7 @@ BuildRequires:  pkgconfig(qtcontacts-sqlite-qt5-extensions) >= 0.2.1
 %package tests
 Summary:    Nemo contact cache library tests
 Group:      System/Libraries
+Requires:   blts-tools
 Requires:   %{name} = %{version}-%{release}
 
 %description tests

--- a/src/seasidecache.cpp
+++ b/src/seasidecache.cpp
@@ -170,6 +170,9 @@ QMap<QString, QString> managerParameters()
     QMap<QString, QString> rv;
     // Report presence changes independently from other contact changes
     rv.insert(QString::fromLatin1("mergePresenceChanges"), QString::fromLatin1("false"));
+    if (!qgetenv("LIBCONTACTS_TEST_MODE").isEmpty()) {
+        rv.insert(QString::fromLatin1("autoTest"), QString::fromLatin1("true"));
+    }
     return rv;
 }
 

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -2,6 +2,7 @@ include(../package.pri)
 
 TEMPLATE = subdirs
 SUBDIRS = tst_synchronizelists tst_seasideimport tst_resolve
+OTHER_FILES += tests.xml.in
 
 tests_xml.target = tests.xml
 tests_xml.depends = $$PWD/tests.xml.in

--- a/tests/tests.xml.in
+++ b/tests/tests.xml.in
@@ -5,13 +5,13 @@
        <set name="contactcache-test0" feature="Contacts">
            <description>Contact cache automatic tests</description>
            <case manual="false" name="synchronizelists">
-               <step>/opt/tests/@PACKAGENAME@/tst_synchronizelists</step>
+               <step>LIBCONTACTS_TEST_MODE=1 /usr/sbin/run-blts-root /bin/su -g privileged -c '/opt/tests/@PACKAGENAME@/tst_synchronizelists' nemo</step>
            </case>
            <case manual="false" name="seasideimport">
-               <step>/opt/tests/@PACKAGENAME@/tst_seasideimport</step>
+               <step>LIBCONTACTS_TEST_MODE=1 /usr/sbin/run-blts-root /bin/su -g privileged -c '/opt/tests/@PACKAGENAME@/tst_seasideimport' nemo</step>
            </case>
            <case manual="false" name="resolve">
-               <step>/opt/tests/@PACKAGENAME@/tst_resolve</step>
+               <step>LIBCONTACTS_TEST_MODE=1 /usr/sbin/run-blts-root /bin/su -g privileged -c '/opt/tests/@PACKAGENAME@/tst_resolve' nemo</step>
            </case>
        </set>
    </suite>

--- a/tests/tst_seasideimport/tst_seasideimport.cpp
+++ b/tests/tst_seasideimport/tst_seasideimport.cpp
@@ -468,10 +468,15 @@ void tst_SeasideImport::mergedUid()
     QCOMPARE(name.isEmpty(), true);
 
     const QList<QContactNickname> nicknames(c.details<QContactNickname>());
-    QCOMPARE(nicknames.count(), 1);
+    QCOMPARE(nicknames.count(), 2);
 
-    const QContactNickname nick(nicknames.at(0));
-    QCOMPARE(nick.nickname(), QString::fromLatin1("Jebediah Springfield"));
+    const QContactNickname nick1(nicknames.at(0));
+    const QContactNickname nick2(nicknames.at(1));
+    QVERIFY(nick1.nickname() == QString::fromLatin1("Jebediah Springfield")
+            || nick1.nickname() == QString::fromLatin1("Obadiah Springfield"));
+    QVERIFY(nick2.nickname() == QString::fromLatin1("Jebediah Springfield")
+            || nick2.nickname() == QString::fromLatin1("Obadiah Springfield"));
+    QVERIFY(nick1.nickname() != nick2.nickname());
 
     const QList<QContactPhoneNumber> phoneNumbers(c.details<QContactPhoneNumber>());
     QCOMPARE(phoneNumbers.count(), 2);
@@ -494,4 +499,4 @@ void tst_SeasideImport::mergedUid()
 }
 
 #include "tst_seasideimport.moc"
-QTEST_APPLESS_MAIN(tst_SeasideImport)
+QTEST_GUILESS_MAIN(tst_SeasideImport)


### PR DESCRIPTION
Commit 813eafc0db80113f79dda9ede2bdc27cd6cf9720 changed how formatted
name (FN) properties from vCards are imported, so that now an import
involving de-duplication can result in a single contact with multiple
nicknames (setNickname() actually adds nicknames if the new nickname
does not match a previously set nickname).

This commit fixes the unit test to take this into account.