### PR TITLE
[libcontacts] Report invalid addresses as unknown. Contributes to MER#1260

### DIFF
--- a/src/seasidecache.cpp
+++ b/src/seasidecache.cpp
@@ -1005,6 +1005,14 @@ SeasideCache::CacheItem *SeasideCache::resolvePhoneNumber(ResolveListener *liste
         const QString normalized(normalizePhoneNumber(number));
         if (!normalized.isEmpty()) {
             instancePtr->resolveAddress(listener, QString(), number, requireComplete);
+        } else {
+            // Report this address is unknown
+            ResolveData data;
+            data.second = number;
+            data.listener = listener;
+
+            instancePtr->m_unknownResolveAddresses.append(data);
+            instancePtr->requestUpdate();
         }
     } else if (requireComplete) {
         ensureCompletion(item);


### PR DESCRIPTION
An invalid address should result in a resolution-to-no-contact event.